### PR TITLE
SIQ-7649 more mysql params

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,20 @@ inputs:
   sqlMode:
     description: 'The sql modes, fx. NO_ENGINE_SUBSTITUTION'
     required: false
+    default: 'NO_ENGINE_SUBSTITUTION'
+  explicitDefaultsForTimestamp:
+    description: 'The --explicit-defaults-for-timestamp flag'
+    required: false
     default: ''
+  characterSetFilesystem:
+    description: 'The --character-set-filesystem flag'
+    required: false
+    default: ''
+  innodbAutoIncLockMode:
+    description: 'The --innodb_autoinc_lock_mode flag'
+    required: false
+    default: ''
+
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,6 +18,7 @@ if [ -n "$INPUT_DATABASE" ]; then
   cmd="$cmd -e MYSQL_DATABASE=$INPUT_DATABASE"
 fi
 
+
 cmd="$cmd -d -p $INPUT_HOSTPORT:$INPUT_CONTAINERPORT"
 cmd="$cmd --hostname=mysql"
 cmd="$cmd --name=mysql"
@@ -25,7 +26,22 @@ cmd="$cmd mysql:$INPUT_VERSION"
 cmd="$cmd --port=$INPUT_CONTAINERPORT"
 cmd="$cmd --character-set-server=$INPUT_CHARACTERSET"
 cmd="$cmd --collation-server=$INPUT_COLLATION"
-cmd="$cmd --sql-mode=NO_ENGINE_SUBSTITUTION"
+
+if [ -n "$INPUT_SQLMODE" ]; then
+  cmd="$cmd --sql-mode=$INPUT_SQLMODE"
+fi
+
+if [ -n "$INPUT_EXPLICITDEFAULTSFORTIMESTAMP" ]; then
+  cmd="$cmd --explicit-defaults-for-timestamp=$INPUT_EXPLICITDEFAULTSFORTIMESTAMP"
+fi
+
+if [ -n "$INPUT_CHARACTERSETFILESYSTEM" ]; then
+  cmd="$cmd --character-set-filesystem=$INPUT_CHARACTERSETFILESYSTEM"
+fi
+
+if [ -n "$INPUT_INNODB_AUTOINC_LOCK_MODE" ]; then
+  cmd="$cmd --innodb_autoinc_lock_mode=$INPUT_CHARACTERSETFILESYSTEM"
+fi
 
 echo "CMD: $cmd"
 


### PR DESCRIPTION
Adds some new parameters for the following mysql flags:
* --explicit-defaults-for-timestamp
* --character-set-filesystem
* --innodb_autoinc_lock_mode

Additionally fixes the existing sqlMode parameter so it's respected